### PR TITLE
Feat invalidate transport

### DIFF
--- a/src/main/java/org/nlab/smtp/pool/ObjectPoolAware.java
+++ b/src/main/java/org/nlab/smtp/pool/ObjectPoolAware.java
@@ -4,6 +4,10 @@ package org.nlab.smtp.pool;
  * Created by nlabrot on 30/04/15.
  */
 public interface ObjectPoolAware {
-
+  /**
+   * Called after the object has been borrowed on the pool to set the pool on the object.
+   *
+   * @param objectPool
+   */
   void setObjectPool(SmtpConnectionPool objectPool);
 }

--- a/src/main/java/org/nlab/smtp/pool/ObjectPoolAware.java
+++ b/src/main/java/org/nlab/smtp/pool/ObjectPoolAware.java
@@ -3,9 +3,7 @@ package org.nlab.smtp.pool;
 /**
  * Created by nlabrot on 30/04/15.
  */
-public interface ObjectPoolAware<T> {
+public interface ObjectPoolAware {
 
   void setObjectPool(SmtpConnectionPool objectPool);
-
-  SmtpConnectionPool getObjectPool();
 }

--- a/src/main/java/org/nlab/smtp/transport/connection/ClosableSmtpConnection.java
+++ b/src/main/java/org/nlab/smtp/transport/connection/ClosableSmtpConnection.java
@@ -17,6 +17,18 @@ public interface ClosableSmtpConnection extends AutoCloseable {
   String HEADER_MESSAGE_ID = "Message-ID";
 
   /**
+   * Marks this pooled object to be invalid such that it is not returned in the pool when closed.
+   * This is equivalent to setInvalid(true).
+   */
+  void invalidate();
+
+  /**
+   * Allows setting the invalid flag to true or false
+   * @param invalid true if the object should not be returned in the pool when closed.
+   */
+  void setInvalid(boolean invalid);
+
+  /**
    * Send a message to a list of recipients
    *
    * @param msg

--- a/src/main/java/org/nlab/smtp/transport/connection/DefaultClosableSmtpConnection.java
+++ b/src/main/java/org/nlab/smtp/transport/connection/DefaultClosableSmtpConnection.java
@@ -27,7 +27,7 @@ public class DefaultClosableSmtpConnection implements ClosableSmtpConnection, Ob
 
   private final Transport delegate;
   private SmtpConnectionPool objectPool;
-  private boolean valid;
+  private boolean shouldInvalidateOnClose;
 
   private final List<TransportListener> transportListeners = new ArrayList<>();
 
@@ -37,12 +37,12 @@ public class DefaultClosableSmtpConnection implements ClosableSmtpConnection, Ob
 
   @Override
   public void invalidate() {
-    valid = false;
+    shouldInvalidateOnClose = true;
   }
 
   @Override
   public void setInvalid(boolean invalid) {
-    valid = !invalid;
+    shouldInvalidateOnClose = invalid;
   }
 
   public void sendMessage(MimeMessage msg, Address[] recipients) throws MessagingException {
@@ -82,7 +82,7 @@ public class DefaultClosableSmtpConnection implements ClosableSmtpConnection, Ob
 
   @Override
   public void close() {
-    if(valid) {
+    if(!shouldInvalidateOnClose) {
       objectPool.returnObject(this);
     } else {
       try {

--- a/src/main/java/org/nlab/smtp/transport/connection/DefaultClosableSmtpConnection.java
+++ b/src/main/java/org/nlab/smtp/transport/connection/DefaultClosableSmtpConnection.java
@@ -19,7 +19,7 @@ import javax.mail.internet.MimeMessage;
 /**
  * Created by nlabrot on 30/04/15.
  */
-public class DefaultClosableSmtpConnection implements ClosableSmtpConnection, ObjectPoolAware<ClosableSmtpConnection> {
+public class DefaultClosableSmtpConnection implements ClosableSmtpConnection, ObjectPoolAware {
 
   private final Transport delegate;
   private SmtpConnectionPool objectPool;
@@ -66,13 +66,8 @@ public class DefaultClosableSmtpConnection implements ClosableSmtpConnection, Ob
 
 
   @Override
-  public void close() throws Exception {
+  public void close() {
     objectPool.returnObject(this);
-  }
-
-  @Override
-  public SmtpConnectionPool getObjectPool() {
-    return objectPool;
   }
 
   @Override
@@ -109,10 +104,9 @@ public class DefaultClosableSmtpConnection implements ClosableSmtpConnection, Ob
   private void doSend(MimeMessage... mimeMessages) throws MailSendException {
     Map<Object, Exception> failedMessages = new LinkedHashMap<>();
 
-    for (int i = 0; i < mimeMessages.length; i++) {
+    for (MimeMessage mimeMessage : mimeMessages) {
 
       // Send message via current transport...
-      MimeMessage mimeMessage = mimeMessages[i];
       try {
         doSend(mimeMessage, mimeMessage.getAllRecipients());
       } catch (Exception ex) {

--- a/src/main/java/org/nlab/smtp/transport/factory/SmtpConnectionFactory.java
+++ b/src/main/java/org/nlab/smtp/transport/factory/SmtpConnectionFactory.java
@@ -32,6 +32,7 @@ public class SmtpConnectionFactory implements PooledObjectFactory<ClosableSmtpCo
   protected final TransportStrategy transportFactory;
   protected final ConnectionStrategy connectionStrategy;
 
+  protected boolean invalidateConnectionOnException;
   protected Collection<TransportListener> defaultTransportListeners;
 
   public SmtpConnectionFactory(Session session, TransportStrategy transportStrategy, ConnectionStrategy connectionStrategy, Collection<TransportListener> defaultTransportListeners) {
@@ -53,7 +54,7 @@ public class SmtpConnectionFactory implements PooledObjectFactory<ClosableSmtpCo
     Transport transport = transportFactory.getTransport(session);
     connectionStrategy.connect(transport);
 
-    DefaultClosableSmtpConnection closableSmtpTransport = new DefaultClosableSmtpConnection(transport);
+    DefaultClosableSmtpConnection closableSmtpTransport = new DefaultClosableSmtpConnection(transport, invalidateConnectionOnException);
     initDefaultListeners(closableSmtpTransport);
 
     return new DefaultPooledObject(closableSmtpTransport);
@@ -100,6 +101,14 @@ public class SmtpConnectionFactory implements PooledObjectFactory<ClosableSmtpCo
 
   public List<TransportListener> getDefaultListeners() {
     return new ArrayList<>(defaultTransportListeners);
+  }
+
+  public boolean isInvalidateConnectionOnException() {
+    return invalidateConnectionOnException;
+  }
+
+  public void setInvalidateConnectionOnException(boolean invalidateConnectionOnException) {
+    this.invalidateConnectionOnException = invalidateConnectionOnException;
   }
 
   public Session getSession() {

--- a/src/test/java/org/nlab/smtp/TestSendException.java
+++ b/src/test/java/org/nlab/smtp/TestSendException.java
@@ -1,0 +1,64 @@
+package org.nlab.smtp;
+
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.junit.Assert;
+import org.junit.Test;
+import org.nlab.smtp.exception.MailSendException;
+import org.nlab.smtp.pool.SmtpConnectionPool;
+import org.nlab.smtp.transport.connection.ClosableSmtpConnection;
+import org.nlab.smtp.transport.factory.SmtpConnectionFactoryBuilder;
+import org.springframework.mail.javamail.MimeMessageHelper;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+
+public class TestSendException extends AbstractTest {
+  @Test
+  public void testReturnedOnException() throws Exception {
+    try (ClosableSmtpConnection connection = smtpConnectionPool.borrowObject()) {
+      MimeMessage mimeMessage = new MimeMessage(connection.getSession());
+      MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false);
+      mimeMessageHelper.addTo("nithril@example.com");
+      mimeMessageHelper.setFrom("nithril@example.com");
+      mimeMessageHelper.setSubject("foo");
+      mimeMessageHelper.setText("example", false);
+      // We stop the server before we actually send the message
+      stopServer();
+      connection.sendMessage(mimeMessage, mimeMessage.getAllRecipients());
+      Assert.fail("The connection should fail since the server is stopped");
+    } catch(MailSendException | MessagingException e) {
+      // It should come here, but the connection should not be returned in the pool
+    }
+    Assert.assertEquals(1, smtpConnectionPool.getBorrowedCount());
+    Assert.assertEquals(1, smtpConnectionPool.getReturnedCount());
+  }
+
+  @Test
+  public void testInvalidateOnException() throws Exception {
+    GenericObjectPoolConfig genericObjectPoolConfig = new GenericObjectPoolConfig();
+    genericObjectPoolConfig.setMaxTotal(getMaxTotalConnection());
+    genericObjectPoolConfig.setTestOnBorrow(true);
+
+    // We need to instantiate a new factory and pool to set the flag on the factory
+    transportFactory = SmtpConnectionFactoryBuilder.newSmtpBuilder().port(PORT).build();
+    transportFactory.setInvalidateConnectionOnException(true);
+    smtpConnectionPool = new SmtpConnectionPool(transportFactory, genericObjectPoolConfig);
+
+    try (ClosableSmtpConnection connection = smtpConnectionPool.borrowObject()) {
+      MimeMessage mimeMessage = new MimeMessage(connection.getSession());
+      MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false);
+      mimeMessageHelper.addTo("nithril@example.com");
+      mimeMessageHelper.setFrom("nithril@example.com");
+      mimeMessageHelper.setSubject("foo");
+      mimeMessageHelper.setText("example", false);
+      // We stop the server before we actually send the message
+      stopServer();
+      connection.sendMessage(mimeMessage, mimeMessage.getAllRecipients());
+      Assert.fail("The connection should fail since the server is stopped");
+    } catch(MailSendException | MessagingException e) {
+      // It should come here, but the connection should not be returned in the pool
+    }
+      Assert.assertEquals(1, smtpConnectionPool.getBorrowedCount());
+    Assert.assertEquals(0, smtpConnectionPool.getReturnedCount());
+  }
+}


### PR DESCRIPTION
This PR adds the possibility to invalidate ClosableSmtpConnection instead of returning them in the pool.

My use case is:
- I do not want to testOnBorrow or testOnReturn since this impacts performance negatively
- If there is no exception when sending emails, return the connection to the pool, it appears to still be good
- If there is an exception, do not return the connection to the pool, it might be bad