### PR TITLE
Upgrade to Jakarta Mail 1.6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # SMTP Connection Pool
 
-This library implements a SMTP connection pool using [Java Mail](https://java.net/projects/javamail/pages/Home) for the SMTP code and the 
+This library implements a SMTP connection pool using [Jakarta Mail](https://eclipse-ee4j.github.io/mail/)
+formerly known as [Java Mail](https://java.net/projects/javamail/pages/Home) for the SMTP code and the
 [Apache Commons Pool](https://commons.apache.org/proper/commons-pool/) for the pool code.
 
 The pool, thanks to the Apache library, supports most common pool features:
@@ -25,7 +26,7 @@ eg.:
 <dependency>
     <groupId>com.github.nithril</groupId>
     <artifactId>smtp-connection-pool</artifactId>
-    <version>1.2.1</version>
+    <version>1.3.0</version>
 </dependency>
 ```
  

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 
 
     <properties>
-        <javax.mail.version>1.6.2</javax.mail.version>
+        <jakarta.mail.version>1.6.4</jakarta.mail.version>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
     </properties>
@@ -46,14 +46,8 @@
 
         <dependency>
             <groupId>com.sun.mail</groupId>
-            <artifactId>javax.mail</artifactId>
-            <version>${javax.mail.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>javax.mail</groupId>
-            <artifactId>javax.mail-api</artifactId>
-            <version>${javax.mail.version}</version>
+            <artifactId>jakarta.mail</artifactId>
+            <version>${jakarta.mail.version}</version>
         </dependency>
 
         <dependency>
@@ -101,6 +95,12 @@
             <artifactId>greenmail</artifactId>
             <version>1.5.7</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.sun.mail</groupId>
+                    <artifactId>javax.mail</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Upgrade to [Jakarta Mail](https://eclipse-ee4j.github.io/mail/) 1.6.4. Jakarte EE is the renamed Java EE which Oracle contributed to the open source community. It uses the same class names as [Java Mail](https://java.net/projects/javamail/pages/Home) in the implementation. The API is different, but the dependency wasn't needed for compilation or testing so I left it out.

I excluded the old Java Mail test dependency in GreenMail to avoid conflicts due to the different artifactId.